### PR TITLE
:sparkles: changed AppointmentFilterDTO

### DIFF
--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/AppointmentController.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/AppointmentController.java
@@ -34,7 +34,7 @@ public class AppointmentController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public Page<AppointmentDetailsResponseDTO> getAppointmentsByPageableAndFilter(@ParameterObject final Pageable pageable,
-            @ParameterObject final AppointmentFilterDTO appointmentFilterDTO) {
+            @Valid @ParameterObject final AppointmentFilterDTO appointmentFilterDTO) {
         final Page<Appointment> appointmentPage = appointmentService.getAppointmentsByPageableAndFilter(pageable, appointmentFilterDTO);
         return appointmentPage.map(appointmentMapper::toDetailsDto);
     }

--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/AppointmentSpecificationBuilder.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/AppointmentSpecificationBuilder.java
@@ -19,8 +19,8 @@ public final class AppointmentSpecificationBuilder {
     public static <T extends Appointment> Specification<T> fromFilter(final AppointmentFilterDTO appointmentFilterDTO) {
         final List<Specification<T>> specificationList = new ArrayList<>();
 
-        if (appointmentFilterDTO.roomId() != null) {
-            specificationList.add(filterForRoomId(appointmentFilterDTO.roomId()));
+        if (appointmentFilterDTO.roomIds() != null && !appointmentFilterDTO.roomIds().isEmpty()) {
+            specificationList.add(filterForRoomIds(appointmentFilterDTO.roomIds()));
         }
         final OffsetDateTime start = appointmentFilterDTO.startDate();
         if (start != null) {
@@ -34,8 +34,8 @@ public final class AppointmentSpecificationBuilder {
         return Specification.allOf(specificationList);
     }
 
-    private static <T extends Appointment> Specification<T> filterForRoomId(final UUID roomId) {
-        return (root, query, cb) -> cb.equal(root.get(Appointment_.booking).get(Booking_.room).get(Room_.id), roomId);
+    private static <T extends Appointment> Specification<T> filterForRoomIds(final List<UUID> roomIds) {
+        return (root, query, cb) -> root.get(Appointment_.booking).get(Booking_.room).get(Room_.id).in(roomIds);
     }
 
     private static <T extends Appointment> Specification<T> filterForStartDate(final OffsetDateTime start) {

--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/dto/AppointmentFilterDTO.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/dto/AppointmentFilterDTO.java
@@ -1,11 +1,14 @@
 package de.muenchen.raumreservierung.appointment.dto;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
+@SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "DTOs are simple data carriers")
 public record AppointmentFilterDTO(
-        OffsetDateTime startDate,
-        OffsetDateTime endDate,
-        @NotNull UUID roomId) {
+        @NotNull OffsetDateTime startDate,
+        @NotNull OffsetDateTime endDate,
+        List<UUID> roomIds) {
 }

--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/booking/dto/BookingMapper.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/booking/dto/BookingMapper.java
@@ -18,6 +18,7 @@ public interface BookingMapper {
     @Mapping(target = "isRecurring", source = "booking", qualifiedByName = "isRecurringCheck")
     BookingListResponseDTO toListDto(Booking booking);
 
+    @Mapping(target = "roomId", source = "room.id")
     BookingMinimalResponseDTO toMinimalDto(Booking booking);
 
     @Mapping(target = "id", ignore = true)

--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/booking/dto/BookingMinimalResponseDTO.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/booking/dto/BookingMinimalResponseDTO.java
@@ -8,5 +8,6 @@ public record BookingMinimalResponseDTO(
         @NotNull UUID id,
         @NotNull String title,
         @NotNull PersonResponseDto bookedBy,
-        @NotNull PersonResponseDto bookedFor) {
+        @NotNull PersonResponseDto bookedFor,
+        UUID roomId) {
 }

--- a/raumreservierung-backend/src/test/java/de/muenchen/raumreservierung/appointment/AppointmentFilterIntegrationTest.java
+++ b/raumreservierung-backend/src/test/java/de/muenchen/raumreservierung/appointment/AppointmentFilterIntegrationTest.java
@@ -1,0 +1,136 @@
+package de.muenchen.raumreservierung.appointment;
+
+import static de.muenchen.raumreservierung.TestConstants.SPRING_TEST_PROFILE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import de.muenchen.raumreservierung.TestConstants;
+import de.muenchen.raumreservierung.appointment.dto.AppointmentDetailsResponseDTO;
+import de.muenchen.raumreservierung.booking.WithMockJwt;
+import de.muenchen.raumreservierung.security.Roles;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles(profiles = { SPRING_TEST_PROFILE })
+@TestPropertySource(
+        properties = {
+                "spring.jpa.hibernate.ddl-auto=validate"
+        }
+)
+public class AppointmentFilterIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    @SuppressWarnings("unused")
+    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(
+            DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
+
+    private static final String APPOINTMENTS_URL = "/appointments";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private org.springframework.security.oauth2.jwt.JwtDecoder jwtDecoder;
+
+    @Test
+    @WithMockJwt(lhmObjectID = "000001", authorities = { Roles.LESEBERECHTIGT })
+    void getAppointmentsByTimePeriod_ShouldReturnAppointments() throws Exception {
+        OffsetDateTime start = OffsetDateTime.now();
+        OffsetDateTime end = OffsetDateTime.now().plusDays(10);
+
+        String responseJson = mockMvc.perform(get(APPOINTMENTS_URL)
+                .param("startDate", start.toString())
+                .param("endDate", end.toString())
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String contentJson = JsonPath.read(responseJson, "$.content").toString();
+        List<AppointmentDetailsResponseDTO> appointments = objectMapper.readValue(
+                contentJson,
+                new TypeReference<>() {
+                });
+
+        assertThat(appointments).isNotEmpty();
+        assertThat(appointments).allSatisfy(appointment -> {
+            assertThat(appointment.schedule().occupancyStart()).isAfterOrEqualTo(start.toLocalDate().atStartOfDay(start.getOffset()).toOffsetDateTime());
+            assertThat(appointment.schedule().occupancyEnd())
+                    .isBeforeOrEqualTo(end.toLocalDate().atTime(LocalTime.MAX).atZone(end.getOffset()).toOffsetDateTime());
+        });
+    }
+
+    @Test
+    @WithMockJwt(lhmObjectID = "000001", authorities = { Roles.LESEBERECHTIGT })
+    void getAppointmentsByPageableAndFilter_WithInvalidFilter_ShouldReturnBadRequest() throws Exception {
+        UUID roomId = UUID.fromString("770e8400-e29b-41d4-a716-446655440001");
+
+        mockMvc.perform(get(APPOINTMENTS_URL)
+                .param("roomIds", roomId.toString())
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isBadRequest());
+
+    }
+
+    @Test
+    @WithMockJwt(lhmObjectID = "000001", authorities = { Roles.LESEBERECHTIGT })
+    void getAppointmentsByTimePeriodAndRoom_ShouldReturnAppointments() throws Exception {
+        OffsetDateTime start = OffsetDateTime.now();
+        OffsetDateTime end = OffsetDateTime.now().plusDays(10);
+        UUID roomId = UUID.fromString("770e8400-e29b-41d4-a716-446655440004");
+
+        String responseJson = mockMvc.perform(get(APPOINTMENTS_URL)
+                .param("roomIds", roomId.toString())
+                .param("startDate", start.toString())
+                .param("endDate", end.toString())
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String contentJson = JsonPath.read(responseJson, "$.content").toString();
+        List<AppointmentDetailsResponseDTO> appointments = objectMapper.readValue(
+                contentJson,
+                new TypeReference<>() {
+                });
+
+        assertThat(appointments).isNotEmpty();
+        assertThat(appointments).allSatisfy(appointment -> {
+            assertThat(appointment.schedule().occupancyStart()).isAfterOrEqualTo(start.toLocalDate().atStartOfDay(start.getOffset()).toOffsetDateTime());
+            assertThat(appointment.schedule().occupancyEnd())
+                    .isBeforeOrEqualTo(end.toLocalDate().atTime(LocalTime.MAX).atZone(end.getOffset()).toOffsetDateTime());
+            assertThat(appointment.bookingMinimal().roomId()).isEqualTo(roomId);
+        });
+    }
+}


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

AppointmentFilterDTO changed to:
- single roomid is no list of roomids and is optional
- start and end date are now mandatory

## Reference

Issue: #181

