### PR TITLE
:sparkles: maintenance: refactor acquiring of appointments related to booking

### DIFF
--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/AppointmentSpecificationBuilder.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/AppointmentSpecificationBuilder.java
@@ -19,6 +19,9 @@ public final class AppointmentSpecificationBuilder {
     public static <T extends Appointment> Specification<T> fromFilter(final AppointmentFilterDTO appointmentFilterDTO) {
         final List<Specification<T>> specificationList = new ArrayList<>();
 
+        if (appointmentFilterDTO.bookingId() != null) {
+            specificationList.add(filterForBookingId(appointmentFilterDTO.bookingId()));
+        }
         if (appointmentFilterDTO.roomId() != null) {
             specificationList.add(filterForRoomId(appointmentFilterDTO.roomId()));
         }
@@ -36,6 +39,10 @@ public final class AppointmentSpecificationBuilder {
 
     private static <T extends Appointment> Specification<T> filterForRoomId(final UUID roomId) {
         return (root, query, cb) -> cb.equal(root.get(Appointment_.booking).get(Booking_.room).get(Room_.id), roomId);
+    }
+
+    private static <T extends Appointment> Specification<T> filterForBookingId(final UUID bookingId) {
+        return (root, query, cb) -> cb.equal(root.get(Appointment_.booking).get(Booking_.id), bookingId);
     }
 
     private static <T extends Appointment> Specification<T> filterForStartDate(final OffsetDateTime start) {

--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/dto/AppointmentFilterDTO.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/appointment/dto/AppointmentFilterDTO.java
@@ -7,5 +7,6 @@ import java.util.UUID;
 public record AppointmentFilterDTO(
         OffsetDateTime startDate,
         OffsetDateTime endDate,
+        UUID bookingId,
         @NotNull UUID roomId) {
 }

--- a/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/booking/dto/BookingDetailResponseDTO.java
+++ b/raumreservierung-backend/src/main/java/de/muenchen/raumreservierung/booking/dto/BookingDetailResponseDTO.java
@@ -1,6 +1,5 @@
 package de.muenchen.raumreservierung.booking.dto;
 
-import de.muenchen.raumreservierung.appointment.dto.AppointmentMinimalResponseDTO;
 import de.muenchen.raumreservierung.booking.ScheduleTemplate;
 import de.muenchen.raumreservierung.equipment.dto.EquipmentResponseDto;
 import de.muenchen.raumreservierung.person.dto.PersonResponseDto;
@@ -20,7 +19,6 @@ public record BookingDetailResponseDTO(
         @NotNull boolean cateringNeeded,
         String internalNotes,
         String additionalNotes,
-        @NotNull List<AppointmentMinimalResponseDTO> appointments,
         RoomListResponseDTO room,
         @NotNull ScheduleTemplate schedule,
         @NotNull PersonResponseDto bookedBy,

--- a/raumreservierung-backend/src/test/java/de/muenchen/raumreservierung/booking/BookingControllerIntegrationTest.java
+++ b/raumreservierung-backend/src/test/java/de/muenchen/raumreservierung/booking/BookingControllerIntegrationTest.java
@@ -272,8 +272,12 @@ public class BookingControllerIntegrationTest {
                 .getContentAsString();
         BookingDetailResponseDTO responseBody = objectMapper.readValue(responseJson, BookingDetailResponseDTO.class);
 
+        OffsetDateTime start = OffsetDateTime.of(2026, 3, 1, 0, 0, 0, 0, ZoneOffset.ofHours(2)).withOffsetSameInstant(ZoneOffset.UTC);
+        OffsetDateTime end = OffsetDateTime.of(2027, 2, 2, 0, 0, 0, 0, ZoneOffset.ofHours(2)).withOffsetSameInstant(ZoneOffset.UTC);
         String appointmentResponseJson = mockMvc.perform(get(APPOINTMENTS_URL).with(csrf())
                 .param("bookingId", responseBody.id().toString())
+                .param("startDate", start.toString())
+                .param("endDate", end.toString())
                 .param("page", "0")
                 .param("size", "10"))
                 .andExpect(status().isOk())

--- a/raumreservierung-backend/src/test/java/de/muenchen/raumreservierung/booking/BookingControllerIntegrationTest.java
+++ b/raumreservierung-backend/src/test/java/de/muenchen/raumreservierung/booking/BookingControllerIntegrationTest.java
@@ -3,13 +3,17 @@ package de.muenchen.raumreservierung.booking;
 import static de.muenchen.raumreservierung.TestConstants.SPRING_TEST_PROFILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
 import de.muenchen.raumreservierung.TestConstants;
+import de.muenchen.raumreservierung.appointment.dto.AppointmentDetailsResponseDTO;
 import de.muenchen.raumreservierung.booking.dto.BookingDetailResponseDTO;
 import de.muenchen.raumreservierung.booking.dto.BookingRequestDTO;
 import de.muenchen.raumreservierung.person.PersonRepository;
@@ -28,7 +32,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,6 +63,7 @@ public class BookingControllerIntegrationTest {
             DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
 
     private static final String BOOKINGS_URL = "/bookings";
+    private static final String APPOINTMENTS_URL = "/appointments";
 
     @Autowired
     private MockMvc mockMvc;
@@ -192,7 +196,7 @@ public class BookingControllerIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("provideTestData")
-    @WithMockJwt(lhmObjectID = "000001", authorities = { Roles.ANWENDER })
+    @WithMockJwt(lhmObjectID = "000001", authorities = { Roles.LESEBERECHTIGT })
     void createBooking_ReturnsCreated_WhenAuthenticatedAndRRules(String rrule, int expectedSize, List<OffsetDateTime> expectedDates) throws Exception {
         OffsetDateTime date = OffsetDateTime.of(2026, 3, 2, 13, 45, 0, 0, ZoneOffset.ofHours(2));
         BookingRequestDTO request = getBookingRequestDTOWithRruleAndBookedFor(date, rrule, mockPerson.getId());
@@ -204,12 +208,25 @@ public class BookingControllerIntegrationTest {
                 .andReturn()
                 .getResponse()
                 .getContentAsString();
-
         BookingDetailResponseDTO responseBody = objectMapper.readValue(responseJson, BookingDetailResponseDTO.class);
 
-        Assertions.assertNotNull(responseBody);
+        String appointmentResponseJson = mockMvc.perform(get(APPOINTMENTS_URL).with(csrf())
+                .param("bookingId", responseBody.id().toString())
+                .param("page", "0")
+                .param("size", "10"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
 
-        assertThat(responseBody.appointments())
+        String contentJson = JsonPath.read(appointmentResponseJson, "$.content").toString();
+        List<AppointmentDetailsResponseDTO> appointments = objectMapper.readValue(
+                contentJson,
+                new TypeReference<>() {
+                });
+
+        assertThat(appointments).isNotEmpty();
+        assertThat(appointments)
                 .hasSize(expectedSize)
                 .extracting(r -> r.schedule().occupancyStart())
                 .containsExactlyInAnyOrderElementsOf(expectedDates);


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- removed list of appointments from booking response dto
- added filter for bookingId to get appointments related to specific booking id

## Reference

Issue: #183

